### PR TITLE
add namespace to role/sa definitions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
+  namespace: openscap
   name: openscap-operator
 rules:
 - apiGroups:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,14 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  namespace: openscap
   name: openscap-operator
 subjects:
 - kind: ServiceAccount
+  namespace: openscap
   name: openscap-operator
 roleRef:
   kind: Role
+  namespace: openscap
   name: openscap-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: openscap
   name: openscap-operator


### PR DESCRIPTION
This lets you use `oc create -f deploy/` regardless of the namespace you're currently in.